### PR TITLE
Create L2 staking adapter with staking NFT

### DIFF
--- a/contracts/UniswapStakerNFT.sol
+++ b/contracts/UniswapStakerNFT.sol
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity =0.7.6;
+pragma abicoder v2;
+
+import './interfaces/IUniswapV3Staker.sol';
+import './libraries/IncentiveId.sol';
+import '@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol';
+import '@openzeppelin/contracts/token/ERC721/ERC721.sol';
+import 'hardhat/console.sol';
+
+contract UniswapStakerNFT is IERC721Receiver, ERC721 {
+    IUniswapV3Staker public immutable staker;
+
+    mapping(bytes32 => IUniswapV3Staker.IncentiveKey) public idToIncentiveKey;
+
+    // id = incentiveIdsByToken[tokenId][i] where i is bound by numberOfStakes inside UniswapV3Staker
+    mapping(uint256 => mapping(uint256 => bytes32)) private incentiveIdsByToken;
+
+    event KeyStored(bytes32 incentiveId, IUniswapV3Staker.IncentiveKey incentiveKey);
+    event PositionEjected(uint256 indexed tokenId, address to);
+
+    constructor(address _staker) ERC721('Uniswap V3 Staked Position', 'UNI-V3-STK') {
+        staker = IUniswapV3Staker(_staker);
+    }
+
+    modifier onlyOwner(uint256 tokenId) {
+        require(ownerOf(tokenId) == msg.sender, 'UniswapStakerNFT::unstakeIncentive: must be token owner');
+        _;
+    }
+
+    function stakedIncentiveIds(uint256 tokenId) external view returns (bytes32[] memory ids) {
+        (, uint256 numStakes, , ) = staker.deposits(tokenId);
+        ids = new bytes32[](numStakes);
+
+        for (uint256 i = 0; i < numStakes; i += 1) {
+            ids[i] = incentiveIdsByToken[tokenId][i];
+        }
+    }
+
+    function numStakedIncentives(uint256 tokenId) external view returns (uint256 numStakes) {
+        (, numStakes, , ) = staker.deposits(tokenId);
+    }
+
+    // Only necessary if incentiveIds runs out of gas
+    function stakedIncentiveId(uint256 tokenId, uint256 i) external view returns (bytes32 id) {
+        return incentiveIdsByToken[tokenId][i];
+    }
+
+    function storeIncentiveKey(IUniswapV3Staker.IncentiveKey memory key) external {
+        bytes32 id = IncentiveId.compute(key);
+        idToIncentiveKey[id] = key;
+        emit KeyStored(id, key);
+    }
+
+    /// @notice Upon receiving a Uniswap V3 ERC721, creates the token deposit setting owner to `from`. Also stakes token
+    /// in one or more incentives if properly formatted `data` has a length > 0.
+    /// @inheritdoc IERC721Receiver
+    function onERC721Received(
+        address,
+        address from,
+        uint256 tokenId,
+        bytes calldata data
+    ) external override returns (bytes4) {
+        if (msg.sender == address(staker.nonfungiblePositionManager())) {
+            _mint(from, tokenId);
+
+            if (data.length == 32) {
+                bytes32 id = abi.decode(data, (bytes32));
+                IUniswapV3Staker.IncentiveKey memory key = _getIncentive(id);
+
+                staker.nonfungiblePositionManager().safeTransferFrom(address(this), address(staker), tokenId, abi.encode(key));
+
+                incentiveIdsByToken[tokenId][0] = id;
+            } else if (data.length > 0 && data.length % 32 == 0) {
+                IUniswapV3Staker.IncentiveKey[] memory keys = new IUniswapV3Staker.IncentiveKey[](data.length / 32);
+
+                for (uint256 i = 0; i < keys.length; i++) {
+                    uint256 start = i * 32;
+                    uint256 end = (i + 1) * 32;
+                    bytes32 id = abi.decode(data[start:end], (bytes32));
+                    keys[i] = _getIncentive(id);
+                    incentiveIdsByToken[tokenId][i] = id;
+                }
+                staker.nonfungiblePositionManager().safeTransferFrom(address(this), address(staker), tokenId, abi.encode(keys));
+            } else {
+                staker.nonfungiblePositionManager().safeTransferFrom(address(this), address(staker), tokenId);
+            }
+        } else if (msg.sender == address(this)) {
+            _claimAndWithdraw(tokenId, from);
+        } else {
+            revert('UniswapStakerNFT::onERC721Received: unknown NFT');
+        }
+        return this.onERC721Received.selector;
+    }
+
+    function claimAndWithdraw(uint256 tokenId) external onlyOwner(tokenId) {
+        _claimAndWithdraw(tokenId, msg.sender);
+    }
+
+    function claimAll(uint256 tokenId) external {
+        address owner = ownerOf(tokenId);
+        (, uint256 numStakes, , ) = staker.deposits(tokenId);
+        
+        for (uint256 i = 0; i < numStakes; i += 1) {
+            bytes32 id = incentiveIdsByToken[tokenId][i];
+            IUniswapV3Staker.IncentiveKey memory key = _getIncentive(id);
+            staker.unstakeToken(key, tokenId);
+            staker.claimReward(key.rewardToken, owner, type(uint256).max);
+            staker.stakeToken(key, tokenId);
+        }
+    }
+
+    function stakeIncentive(uint256 tokenId, bytes32 id) external onlyOwner(tokenId) {
+        IUniswapV3Staker.IncentiveKey memory key = _getIncentive(id);
+
+        staker.stakeToken(key, tokenId);
+
+        (, uint256 numStakes, , ) = staker.deposits(tokenId);
+        incentiveIdsByToken[tokenId][numStakes - 1] = id;
+    }
+
+    function unstakeIncentive(uint256 tokenId, uint256 i) external onlyOwner(tokenId) {
+        require(ownerOf(tokenId) == msg.sender);
+        (, uint256 numStakes, , ) = staker.deposits(tokenId);
+        require(i < numStakes, 'UniswapStakerNFT::unstakeIncentive: invalid incentive ID');
+
+        bytes32 id = incentiveIdsByToken[tokenId][i];
+        IUniswapV3Staker.IncentiveKey memory key = _getIncentive(id);
+
+        staker.unstakeToken(key, tokenId);
+        staker.claimReward(key.rewardToken, msg.sender, type(uint256).max);
+
+        if (i != numStakes - 1) {
+            // Remove the incentive from the list by swapping the end of the list in
+            incentiveIdsByToken[tokenId][i] = incentiveIdsByToken[tokenId][numStakes - 1];
+        }
+        incentiveIdsByToken[tokenId][numStakes - 1] = bytes32(0);
+    }
+
+    function eject(uint256 tokenId) external onlyOwner(tokenId) {
+        _burn(tokenId);
+        staker.transferDeposit(tokenId, msg.sender);
+        emit PositionEjected(tokenId, msg.sender);
+    }
+
+    function _claimAndWithdraw(uint256 tokenId, address recipient) private {
+        _burn(tokenId);
+
+        (, uint256 numStakes, , ) = staker.deposits(tokenId);
+
+        // If the token has too many stakes, this loop may hit the gas limit
+        for (uint256 i = 0; i < numStakes; i += 1) {
+            bytes32 id = incentiveIdsByToken[tokenId][i];
+            IUniswapV3Staker.IncentiveKey memory key = _getIncentive(id);
+            staker.unstakeToken(key, tokenId);
+            staker.claimReward(key.rewardToken, recipient, type(uint256).max);
+            incentiveIdsByToken[tokenId][i] = bytes32(0); // Not strictly necessary, but we'll clean up the state and get a refund
+        }
+
+        staker.withdrawToken(tokenId, recipient, new bytes(0));
+    }
+
+    function _getIncentive(bytes32 id) private view returns (IUniswapV3Staker.IncentiveKey memory key) {
+        key = idToIncentiveKey[id];
+        require(address(key.rewardToken) != address(0), 'UniswapStakerNFT: unknown incentive');
+    }
+}

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -14,6 +14,7 @@ import { ISwapRouter } from '../../types/ISwapRouter'
 import { IWETH9 } from '../../types/IWETH9'
 import {
   UniswapV3Staker,
+  UniswapStakerNFT,
   TestERC20,
   INonfungiblePositionManager,
   IUniswapV3Factory,
@@ -207,6 +208,7 @@ export type UniswapFixtureType = {
   poolObj: IUniswapV3Pool
   router: ISwapRouter
   staker: UniswapV3Staker
+  stakerNFT: UniswapStakerNFT
   testIncentiveId: TestIncentiveId
   tokens: [TestERC20, TestERC20, TestERC20]
   token0: TestERC20
@@ -218,6 +220,9 @@ export const uniswapFixture: Fixture<UniswapFixtureType> = async (wallets, provi
   const signer = new ActorFixture(wallets, provider).stakerDeployer()
   const stakerFactory = await ethers.getContractFactory('UniswapV3Staker', signer)
   const staker = (await stakerFactory.deploy(factory.address, nft.address, 2 ** 32, 2 ** 32)) as UniswapV3Staker
+
+  const stakerNFTFactory = await ethers.getContractFactory('UniswapStakerNFT', signer)
+  const stakerNFT = (await stakerNFTFactory.deploy(staker.address)) as UniswapStakerNFT
 
   const testIncentiveIdFactory = await ethers.getContractFactory('TestIncentiveId', signer)
   const testIncentiveId = (await testIncentiveIdFactory.deploy()) as TestIncentiveId
@@ -242,6 +247,7 @@ export const uniswapFixture: Fixture<UniswapFixtureType> = async (wallets, provi
     router,
     tokens,
     staker,
+    stakerNFT,
     testIncentiveId,
     factory,
     pool01,

--- a/test/unit/UniswapStakerNFT.spec.ts
+++ b/test/unit/UniswapStakerNFT.spec.ts
@@ -1,0 +1,387 @@
+import { BigNumber, constants, Wallet } from 'ethers'
+import { LoadFixtureFunction } from '../types'
+import { TestERC20 } from '../../typechain'
+import { uniswapFixture, mintPosition, UniswapFixtureType } from '../shared/fixtures'
+import {
+  expect,
+  getMaxTick,
+  getMinTick,
+  FeeAmount,
+  TICK_SPACINGS,
+  blockTimestamp,
+  BN,
+  BNe,
+  BNe18,
+  snapshotGasCost,
+  ActorFixture,
+  makeTimestamps,
+  maxGas,
+} from '../shared'
+import { createFixtureLoader, provider } from '../shared/provider'
+import { HelperCommands, ERC20Helper, incentiveResultToStakeAdapter } from '../helpers'
+import { ContractParams } from '../../types/contractParams'
+import { createTimeMachine } from '../shared/time'
+import { HelperTypes } from '../helpers/types'
+
+let loadFixture: LoadFixtureFunction
+
+describe('unit/V3StakerNFT', () => {
+  const actors = new ActorFixture(provider.getWallets(), provider)
+  const incentiveCreator = actors.incentiveCreator()
+  const lpUser0 = actors.lpUser0()
+  const amountDesired = BNe18(10)
+  const totalReward = BNe18(100)
+  const erc20Helper = new ERC20Helper()
+  const Time = createTimeMachine(provider)
+  let helpers: HelperCommands
+  let context: UniswapFixtureType
+  let timestamps: ContractParams.Timestamps
+  let tokenId: string
+  let incentiveId: string
+  let incentiveKey: ContractParams.IncentiveKey
+
+  before('loader', async () => {
+    loadFixture = createFixtureLoader(provider.getWallets(), provider)
+  })
+
+  beforeEach('create fixture loader', async () => {
+    context = await loadFixture(uniswapFixture)
+    helpers = HelperCommands.fromTestContext(context, actors, provider)
+
+    timestamps = makeTimestamps((await blockTimestamp()) + 1_000)
+    incentiveKey = {
+      rewardToken: context.rewardToken.address,
+      pool: context.pool01,
+      startTime: timestamps.startTime,
+      endTime: timestamps.endTime,
+      refundee: incentiveCreator.address,
+    }
+    incentiveId = await context.testIncentiveId.compute(incentiveKey)
+
+    await erc20Helper.ensureBalancesAndApprovals(
+      lpUser0,
+      [context.token0, context.token1],
+      amountDesired,
+      context.nft.address
+    )
+
+    tokenId = await mintPosition(context.nft.connect(lpUser0), {
+      token0: context.token0.address,
+      token1: context.token1.address,
+      fee: FeeAmount.MEDIUM,
+      tickLower: getMinTick(TICK_SPACINGS[FeeAmount.MEDIUM]),
+      tickUpper: getMaxTick(TICK_SPACINGS[FeeAmount.MEDIUM]),
+      recipient: lpUser0.address,
+      amount0Desired: amountDesired,
+      amount1Desired: amountDesired,
+      amount0Min: 0,
+      amount1Min: 0,
+      deadline: (await blockTimestamp()) + 1000,
+    })
+
+    await helpers.createIncentiveFlow({
+      rewardToken: context.rewardToken,
+      totalReward,
+      poolAddress: context.poolObj.address,
+      ...timestamps,
+    })
+  })
+
+  describe('#storeIncentiveKey', () => {
+    it('stores a key', async () => {
+      const resultKey = [
+        context.rewardToken.address,
+        context.pool01,
+        BN(timestamps.startTime),
+        BN(timestamps.endTime),
+        incentiveCreator.address,    
+      ]
+
+      await expect(context.stakerNFT.storeIncentiveKey(incentiveKey))
+        .to.emit(context.stakerNFT, 'KeyStored')
+        .withArgs(incentiveId, resultKey)
+
+      expect(await context.stakerNFT.idToIncentiveKey(incentiveId)).to.deep.equal(resultKey)
+    })
+  })
+
+  describe('#onERC721Received', () => {
+    beforeEach(async () => {
+      await Time.set(timestamps.startTime + 1)
+      await context.stakerNFT.storeIncentiveKey(incentiveKey)
+    })
+
+    describe('receiving a UniswapV3Position NFT', () => {
+      it('should deposit without any data', async () => {
+        await expect(context.nft
+          .connect(lpUser0)
+          ['safeTransferFrom(address,address,uint256)'](lpUser0.address, context.stakerNFT.address, tokenId, {
+            ...maxGas,
+            from: lpUser0.address,
+          })
+        )
+          .to.emit(context.stakerNFT, 'Transfer')
+          .withArgs(constants.AddressZero, lpUser0.address, tokenId)
+
+        expect(await context.nft.ownerOf(tokenId)).to.equal(context.staker.address)
+        expect(await context.stakerNFT.ownerOf(tokenId)).to.equal(lpUser0.address)
+        expect(await context.stakerNFT.stakedIncentiveIds(tokenId)).to.deep.equal([])
+      })
+
+      it('should deposit with a single incentive', async () => {
+        await expect(context.nft
+          .connect(lpUser0)
+          ['safeTransferFrom(address,address,uint256,bytes)'](lpUser0.address, context.stakerNFT.address, tokenId, incentiveId, {
+            ...maxGas,
+            from: lpUser0.address,
+          })
+        )
+          .to.emit(context.stakerNFT, 'Transfer')
+          .withArgs(constants.AddressZero, lpUser0.address, tokenId)
+
+        expect(await context.nft.ownerOf(tokenId)).to.equal(context.staker.address)
+        expect(await context.stakerNFT.ownerOf(tokenId)).to.equal(lpUser0.address)
+        expect(await context.stakerNFT.stakedIncentiveIds(tokenId)).to.deep.equal([incentiveId])
+      })
+
+      it('should deposit with multiple incentives')
+    })
+
+    describe('receiving a V3StakerNFT NFT', () => {
+      beforeEach(async () => {
+        await context.nft
+          .connect(lpUser0)
+          ['safeTransferFrom(address,address,uint256,bytes)'](lpUser0.address, context.stakerNFT.address, tokenId, incentiveId, {
+            ...maxGas,
+            from: lpUser0.address,
+          })
+
+        await Time.setAndMine(timestamps.startTime + 10)
+      })
+
+      it('should unstake the position and claim rewards', async () => {
+        let rewardInfo = await context.staker.getRewardInfo(incentiveKey, tokenId)
+
+        await expect(context.stakerNFT
+          .connect(lpUser0)
+          ['safeTransferFrom(address,address,uint256)'](lpUser0.address, context.stakerNFT.address, tokenId, {
+            ...maxGas,
+            from: lpUser0.address,
+          })
+        )
+          .to.emit(context.stakerNFT, 'Transfer')
+          .withArgs(context.stakerNFT.address, constants.AddressZero, tokenId)
+          .to.emit(context.nft, 'Transfer')
+          .withArgs(context.staker.address, lpUser0.address, tokenId)
+          .to.emit(context.staker, 'RewardClaimed')
+
+        expect((await context.rewardToken.balanceOf(lpUser0.address)).gte(rewardInfo.reward))
+        expect(await context.nft.ownerOf(tokenId)).to.equal(lpUser0.address)
+      })
+    })
+
+    describe('on invalid call', async () => {
+      it('reverts when called by an unknown token', async () => {
+        await expect(
+          context.stakerNFT.connect(lpUser0).onERC721Received(incentiveCreator.address, lpUser0.address, 1, [])
+        ).to.be.revertedWith('UniswapStakerNFT::onERC721Received: unknown NFT')
+      })
+
+      it('reverts when staking on invalid incentive')
+    })
+  })
+
+  describe('#claimAndWithdraw', () => {
+    beforeEach(async () => {
+      await Time.set(timestamps.startTime + 1)
+      await context.stakerNFT.storeIncentiveKey(incentiveKey)
+
+      await context.nft
+        .connect(lpUser0)
+        ['safeTransferFrom(address,address,uint256,bytes)'](lpUser0.address, context.stakerNFT.address, tokenId, incentiveId, {
+          ...maxGas,
+          from: lpUser0.address,
+        })
+
+      await Time.setAndMine(timestamps.startTime + 10)
+    })
+
+    it('claim all rewards and withdraw', async () => {
+      let rewardInfo = await context.staker.getRewardInfo(incentiveKey, tokenId)
+
+      await expect(context.stakerNFT.connect(lpUser0).claimAndWithdraw(tokenId))
+        .to.emit(context.stakerNFT, 'Transfer')
+        .withArgs(lpUser0.address, constants.AddressZero, tokenId)
+        .to.emit(context.nft, 'Transfer')
+        .withArgs(context.staker.address, lpUser0.address, tokenId)
+        .to.emit(context.staker, 'RewardClaimed')
+
+      expect((await context.rewardToken.balanceOf(lpUser0.address)).gte(rewardInfo.reward))
+      expect(await context.nft.ownerOf(tokenId)).to.equal(lpUser0.address)
+    })
+  })
+
+  describe('#claimAll', () => {
+    beforeEach(async () => {
+      await Time.set(timestamps.startTime + 1)
+      await context.stakerNFT.storeIncentiveKey(incentiveKey)
+
+      await context.nft
+        .connect(lpUser0)
+        ['safeTransferFrom(address,address,uint256,bytes)'](lpUser0.address, context.stakerNFT.address, tokenId, incentiveId, {
+          ...maxGas,
+          from: lpUser0.address,
+        })
+
+      await Time.setAndMine(timestamps.startTime + 10)
+    })
+
+    it('claim all rewards', async () => {
+      let rewardInfo = await context.staker.getRewardInfo(incentiveKey, tokenId)
+
+      await expect(context.stakerNFT.connect(lpUser0).claimAll(tokenId))
+        .to.emit(context.staker, 'RewardClaimed')
+
+      expect((await context.rewardToken.balanceOf(lpUser0.address)).gte(rewardInfo.reward))
+    })
+  })
+
+  describe('#stakeIncentive', () => {
+    let incentiveId2: string
+    let incentiveKey2: ContractParams.IncentiveKey
+
+    beforeEach(async () => {
+      await Time.set(timestamps.startTime + 1)
+      await context.stakerNFT.storeIncentiveKey(incentiveKey)
+
+      await context.nft
+        .connect(lpUser0)
+        ['safeTransferFrom(address,address,uint256,bytes)'](lpUser0.address, context.stakerNFT.address, tokenId, incentiveId, {
+          ...maxGas,
+          from: lpUser0.address,
+        })
+
+      const timestamps2 = makeTimestamps((await blockTimestamp()) + 1_000)
+
+      const incentive = await helpers.createIncentiveFlow({
+        rewardToken: context.rewardToken,
+        totalReward,
+        poolAddress: context.poolObj.address,
+        ...timestamps2,
+      })
+
+      incentiveKey2 = {
+        rewardToken: context.rewardToken.address,
+        pool: context.pool01,
+        startTime: timestamps2.startTime,
+        endTime: timestamps2.endTime,
+        refundee: incentiveCreator.address,
+      }
+      incentiveId2 = await context.testIncentiveId.compute(incentiveKey2)
+      await context.stakerNFT.storeIncentiveKey(incentiveKey2)
+      await Time.set(timestamps2.startTime + 1)
+    })
+
+    it('stake a new incentive', async () => {
+      const [, liquidity] = await context.staker.stakes(tokenId, incentiveId)
+
+      expect(await context.stakerNFT.stakedIncentiveIds(tokenId)).to.deep.equal([incentiveId])
+
+      await expect(context.stakerNFT.connect(lpUser0).stakeIncentive(tokenId, incentiveId2))
+        .to.emit(context.staker, 'TokenStaked')
+        .withArgs(tokenId, incentiveId2, liquidity)
+
+      expect(await context.stakerNFT.stakedIncentiveIds(tokenId)).to.deep.equal([incentiveId, incentiveId2])
+    })
+  })
+
+  describe('#unstakeIncentive', () => {
+    let incentiveId2: string
+    let incentiveKey2: ContractParams.IncentiveKey
+
+    beforeEach(async () => {
+      await Time.setAndMine(timestamps.startTime + 1)
+      await context.stakerNFT.storeIncentiveKey(incentiveKey)
+
+      const timestamps2 = makeTimestamps((await blockTimestamp()) + 100)
+
+      await helpers.createIncentiveFlow({
+        rewardToken: context.rewardToken,
+        totalReward,
+        poolAddress: context.poolObj.address,
+        ...timestamps2,
+      })
+
+      incentiveKey2 = {
+        rewardToken: context.rewardToken.address,
+        pool: context.pool01,
+        startTime: timestamps2.startTime,
+        endTime: timestamps2.endTime,
+        refundee: incentiveCreator.address,
+      }
+      incentiveId2 = await context.testIncentiveId.compute(incentiveKey2)
+      await context.stakerNFT.storeIncentiveKey(incentiveKey2)
+      await Time.set(timestamps2.startTime + 1)
+      
+      const incentives = incentiveId + incentiveId2.substring(2)
+      await context.nft
+        .connect(lpUser0)
+        ['safeTransferFrom(address,address,uint256,bytes)'](lpUser0.address, context.stakerNFT.address, tokenId, incentives, {
+          ...maxGas,
+          from: lpUser0.address,
+        })
+    })
+
+    it('unstake and claim both incentives', async () => {
+      expect(await context.stakerNFT.stakedIncentiveIds(tokenId)).to.deep.equal([incentiveId, incentiveId2])
+
+      await expect(context.stakerNFT.connect(lpUser0).unstakeIncentive(tokenId, 0))
+        .to.emit(context.staker, 'TokenUnstaked')
+        .withArgs(tokenId, incentiveId)
+        .to.emit(context.staker, 'RewardClaimed')
+
+      expect(await context.stakerNFT.stakedIncentiveIds(tokenId)).to.deep.equal([incentiveId2])
+
+      await expect(context.stakerNFT.connect(lpUser0).unstakeIncentive(tokenId, 0))
+        .to.emit(context.staker, 'TokenUnstaked')
+        .withArgs(tokenId, incentiveId2)
+        .to.emit(context.staker, 'RewardClaimed')
+
+      expect(await context.stakerNFT.stakedIncentiveIds(tokenId)).to.deep.equal([])
+    })
+
+    describe('on invalid call', () => {
+      it('should revert if invalid index passed', async () => {
+        await expect(context.stakerNFT.connect(lpUser0).unstakeIncentive(tokenId, 10))
+          .to.be.revertedWith('UniswapStakerNFT::unstakeIncentive: invalid incentive ID')
+      })
+    })
+  })
+
+  describe('#eject', () => {
+    beforeEach(async () => {
+      await Time.set(timestamps.startTime + 1)
+      await context.stakerNFT.storeIncentiveKey(incentiveKey)
+
+      await context.nft
+        .connect(lpUser0)
+        ['safeTransferFrom(address,address,uint256,bytes)'](lpUser0.address, context.stakerNFT.address, tokenId, incentiveId, {
+          ...maxGas,
+          from: lpUser0.address,
+        })
+    })
+
+    it('exect position from staker NFT', async () => {
+      await expect(context.stakerNFT.connect(lpUser0).eject(tokenId))
+        .to.emit(context.stakerNFT, 'Transfer')
+        .withArgs(lpUser0.address, constants.AddressZero, tokenId)
+        .to.emit(context.stakerNFT, 'PositionEjected')
+        .withArgs(tokenId, lpUser0.address)
+        .to.emit(context.staker, 'DepositTransferred')
+        .withArgs(tokenId, context.stakerNFT.address, lpUser0.address)
+
+      expect((await context.staker.deposits(tokenId))[0]).to.equal(lpUser0.address)
+      expect(await context.nft.ownerOf(tokenId)).to.equal(context.staker.address)
+    })
+  })
+})


### PR DESCRIPTION
This PR creates UniswapStakerNFT, a helper contract that sits on top of UniswapV3Staker.

The goals of this contract are:

* Improve the overall UX of staking UniV3 NFT positions
* Reduce the transaction fees required to stake/unstake
* Reduce the number of transactions needed

On L1, calldata is one of the cheapest resources available to a smart contract, while on L2, it is one of the most expensive. Therefore, this contract aims to reduce gas fees by reducing calldata needed for transactions.

One primary way it does this is instead of users providing a 192-byte IncentiveKey struct to function calls, they simply provide a 32-byte incentiveID hash. The struct is stored internally by the contract, and is passed onwards to UniswapV3Staker on many transactions.

The contract will also internally track which which incentiveIds belong to each staked position. This allows users to claim all rewards & withdraw their position in a single transaction, with minimal calldata required.

This contract also represents staked Uniswap positions as NFTs, allowing them to be transferred and viewed in the user's wallet.